### PR TITLE
Wrap text query filter in parenthesis

### DIFF
--- a/src/lib/api/solr-query.js
+++ b/src/lib/api/solr-query.js
@@ -36,7 +36,7 @@ const textFieldToQueryFilter = (field) => {
     return null;
   }
 
-  return encodeURIComponent(field.field === "*" ? value : `${field.field}:${value}`);
+  return encodeURIComponent(field.field === "*" ? value : `${field.field}:(${value})`);
 };
 
 const fieldToQueryFilter = (field) => {


### PR DESCRIPTION
This solves two problems:
- in case a search field contains multiple terms, only the first one was actually restricted to the field
- text searches could not start with an operator (like "-term")